### PR TITLE
Fix dragon backpack Strength

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/common/BackpackAbilities.java
+++ b/src/main/java/com/darkona/adventurebackpack/common/BackpackAbilities.java
@@ -427,8 +427,8 @@ public class BackpackAbilities
         if (player.isPotionActive(Potion.damageBoost.id)) {
             potion = player.getActivePotionEffect(Potion.damageBoost);
         }
-        if (potion == null || potion.getDuration() < 40 && potion.getAmplifier() != -5) {
-            player.addPotionEffect(new PotionEffect(Potion.damageBoost.getId(), 5000, -5));
+        if (potion == null || potion.getDuration() < 40 && potion.getAmplifier() != 2) {
+            player.addPotionEffect(new PotionEffect(Potion.damageBoost.getId(), 5000, 2));
         }
     }
 


### PR DESCRIPTION
Just to note, the strength and regen effects cannot be automatically removed if the backpack is not worn, as that would cause issues with normal potions. This could be fixed by registering a custom enchantment for each of these, but that seems a little overcomplicated.